### PR TITLE
Fix the AWS NSG creating steps to make rules work

### DIFF
--- a/ncsp/aws_funcs.py
+++ b/ncsp/aws_funcs.py
@@ -456,7 +456,7 @@ class CSPClass(CSPBaseClass):
         
         outer_retcode = 0
         for idx in range(0, len(ingress)):
-            self.Inform("CreateNSG rule %s.%s" % args.nsg_name, ingress[idx]["Name"] )        
+            self.Inform("CreateNSG rule %s.%s" % (args.nsg_name, ingress[idx]["Description"]))
 
             cmd =  "aws ec2 authorize-security-group-ingress"
             cmd += " --group-id %s" % args.nsg_id


### PR DESCRIPTION
Check the ingress directory below.  And self.Inform will return another syntax issue.  
As a result, the following rules will not be created in the security group - however the group itself will remain.  I'm also thinking about a rollback here to let the empty SG being removed in the creation failure, so that it will not impact the coming VM hosts.
The created VM cannot be connected by any means as the ports are disabled.

> /home/yyy/script/ngc-examples/ncsp/aws_funcs.py(460)CreateSecurityGroup()
-> self.Inform("CreateNSG rule %s.%s" % args.nsg_name, ingress[idx]["Name"] )
(Pdb) p args.nsg_name
'yyyNSG'
(Pdb) p ingress
{0: {'ToPort': 22, 'IpProtocol': 'tcp', 'CidrIp': '0.0.0.0/0', 'Description': 'For SSH', 'FromPort': 22}, 1: {'ToPort': 443, 'IpProtocol': 'tcp', 'CidrIp': '0.0.0.0/0', 'Description': 'For SSL', 'FromPort': 443}, 2: {'ToPort': 5000, 'IpProtocol': 'tcp', 'CidrIp': '0.0.0.0/0', 'Description': 'For NVIDIA DIGITS6', 'FromPort': 5000}, 3: {'ToPort': -1, 'IpProtocol': 'icmp', 'CidrIp': '0.0.0.0/0', 'Description': 'To allow to be pinged', 'FromPort': 8}}
(Pdb) p ingress[idx]["Name"]
*** KeyError: KeyError('Name',)